### PR TITLE
extend link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -62,6 +62,6 @@ Our loader app supports localizations while palera1n CLI does not; if you feel t
 </p>
 
 
-###### Other credits can be found [here](https://palera.in/other-credits).
+###### [Other credits can be found here](https://palera.in/other-credits).
 
 </td></tr></table>


### PR DESCRIPTION
the previous version would, if you clicked somewhere other than the "here", take you to the location on the readme (Sorry that my explanation of this is prob shit, I'm bad at saying stuff, but try to click on it on a location other than the here if you don't understand what I mean). I'm pretty sure this is unintentional, so I fixed this.